### PR TITLE
fix: Move `connectAndSend()` to seperate java thread

### DIFF
--- a/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNBLEPrinterModule.java
@@ -76,10 +76,12 @@ public class RNBLEPrinterModule extends ReactContextBaseJavaModule implements RN
 
     @ReactMethod
     public void connectAndSend(String innerAddress, String base64Data, String brand,String series, Callback successCallback, Callback errorCallback) {
-        this.adapter = BLEPrinterAdapter.getInstance();
-        this.adapter.init(reactContext,  null, null);
+      new Thread(() -> {
+        adapter = BLEPrinterAdapter.getInstance();
+        adapter.init(reactContext,  null, null);
         adapter.connectAndSend(BLEPrinterDeviceId.valueOf(innerAddress), base64Data, successCallback, errorCallback);
-        this.adapter.closeConnectionIfExists();
+        adapter.closeConnectionIfExists();
+      }).start();
     }
 
     @ReactMethod

--- a/android/src/main/java/com/pinmi/react/printer/RNNetPrinterModule.java
+++ b/android/src/main/java/com/pinmi/react/printer/RNNetPrinterModule.java
@@ -59,11 +59,13 @@ public class RNNetPrinterModule extends ReactContextBaseJavaModule implements RN
 
     @ReactMethod
     public void connectAndSend(String host, Integer port, String data, String brand,String series, Callback successCallback, Callback errorCallback) {
-        this.adapter = NetPrinterAdapter.getInstance();
-        this.adapter.init(reactContext,  null, null);
+      new Thread(() -> {
+        adapter = NetPrinterAdapter.getInstance();
+        adapter.init(reactContext,  null, null);
 
         adapter.connectAndSend(host, port, data, successCallback, errorCallback);
-        this.adapter.closeConnectionIfExists();
+        adapter.closeConnectionIfExists();
+      }).start();
     }
 
     @ReactMethod


### PR DESCRIPTION
## Description
Move `connectAndSend()` to seperate java thread so that the react's UI will not be blocked while printing is going on.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)